### PR TITLE
Fix attachment_url vs url problem

### DIFF
--- a/index.php
+++ b/index.php
@@ -321,8 +321,14 @@ function attachment_importer_uploader(){
 			)
 		);
 	}
-
-	$remote_url = ! empty($parameters['attachment_url']) ? $parameters['attachment_url'] : $parameters['guid'];
+	
+	if(!empty($parameters['attachment_url'])) {
+		$remote_url = $parameters['attachment_url'];
+	} elseif(!empty($parameters['url'])) {
+		$remote_url = $parameters['url'];
+	} else {
+		$remote_url = $parameters['guid'];
+	}
 	
 	echo json_encode( process_attachment( $parameters, $remote_url ) );
 


### PR DESCRIPTION
In my Wordpress file, the GUID did not match the URL for the files... this uncovered a bug in the importer.
The image URL is not found in "attachment_url", but in the field "url". I'm not sure if this is a break between different WP versions, so instead of replacing the original I've augmented it, just to make sure.
