### PR TITLE
Update index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -285,9 +285,13 @@ function attachment_importer_uploader(){
 
 		$filesize = filesize( $upload['file'] );
 
-		if ( isset( $headers['content-length'] ) && $filesize != $headers['content-length'] ) {
-			@unlink( $upload['file'] );
-			return new WP_Error( 'import_file_error', __('Remote file is incorrect size', 'attachment-importer') );
+		// Gzip encoding results in a different content-length being transmitted than the actual filesize.
+		if ( isset( $headers['content-encoding']) && $headers['content-encoding'] !== 'gzip') {
+			if ( isset( $headers['content-length'] ) && $filesize != $headers['content-length'] ) {
+				@unlink( $upload['file'] );
+				var_dump($headers);die();
+				return new WP_Error( 'import_file_error', __('Remote file '.$url.' is incorrect size, expected '.$headers['content-length'].', got '.$filesize, 'attachment-importer') );
+			}
 		}
 
 		if ( 0 == $filesize ) {


### PR DESCRIPTION
Ran into the same issue as poster of #16. Gzip encoding causes different between content-length of the HTTP message and the actual amount of bytes stored on disk. Added an explicit check for gzip-encoding, if so, skip the filesize check. Perhaps that check should be abolished entirely?
